### PR TITLE
Other: Rename Result methods containing apply to flatMap

### DIFF
--- a/domain/src/main/java/com/htecgroup/androidcore/domain/extension/ResultExt.kt
+++ b/domain/src/main/java/com/htecgroup/androidcore/domain/extension/ResultExt.kt
@@ -19,7 +19,7 @@ package com.htecgroup.androidcore.domain.extension
 /**
  * Applies [block] function on [DataT] and wraps the result [OutT] into [Result].
  */
-suspend fun <OutT : Any, DataT : Any> Result<DataT>.apply(
+suspend fun <OutT : Any, DataT : Any> Result<DataT>.flatMap(
     block: suspend (DataT?) -> Result<OutT>
 ): Result<OutT> {
     val exception = exceptionOrNull()
@@ -34,7 +34,7 @@ suspend fun <OutT : Any, DataT : Any> Result<DataT>.apply(
  * Applies [block] function on [DataT] if it's non-null, and wraps the result [OutT] into [Result].
  * Returns success if [DataT] is null.
  */
-suspend fun <OutT : Any, DataT : Any> Result<DataT?>.applyIfSome(
+suspend fun <OutT : Any, DataT : Any> Result<DataT?>.flatMapIfSome(
     block: suspend (DataT) -> Result<OutT?>
 ): Result<OutT?> {
     val data: DataT? = getOrNull()

--- a/sample/data/src/main/java/com/htecgroup/coresample/data/repositories/PostRepositoryImpl.kt
+++ b/sample/data/src/main/java/com/htecgroup/coresample/data/repositories/PostRepositoryImpl.kt
@@ -17,7 +17,7 @@
 package com.htecgroup.coresample.data.repositories
 
 import com.htecgroup.androidcore.data.CoreRepository
-import com.htecgroup.androidcore.domain.extension.applyIfSome
+import com.htecgroup.androidcore.domain.extension.flatMapIfSome
 import com.htecgroup.androidcore.domain.extension.mapWrapListResult
 import com.htecgroup.androidcore.domain.extension.mapWrapResult
 import com.htecgroup.androidcore.domain.extension.toUnitResult
@@ -62,18 +62,18 @@ class PostRepositoryImpl @Inject constructor(
             postApi.getPosts()
         }
             .map { posts -> posts.map { it.toPostEntity() } }
-            .applyIfSome { safeDbCall { postDao.updatePosts(it) } }
+            .flatMapIfSome { safeDbCall { postDao.updatePosts(it) } }
             .toUnitResult()
 
     override suspend fun fetchPost(postId: Int): Result<Unit> =
         safeApiCall { postApi.getPost(postId) }
             .map { it.toPostEntity() }
-            .applyIfSome { safeDbCall { postDao.insert(it) } }
+            .flatMapIfSome { safeDbCall { postDao.insert(it) } }
             .toUnitResult()
 
     override suspend fun addPost(post: Post): Result<Unit> =
         safeApiCall { postApi.addPost(post.toPostRaw()) }
             .map { postRaw -> postRaw.toPostEntity() }
-            .applyIfSome { safeDbCall { postDao.insert(it) } }
+            .flatMapIfSome { safeDbCall { postDao.insert(it) } }
             .toUnitResult()
 }

--- a/sample/data/src/main/java/com/htecgroup/coresample/data/repositories/UserRepositoryImpl.kt
+++ b/sample/data/src/main/java/com/htecgroup/coresample/data/repositories/UserRepositoryImpl.kt
@@ -17,7 +17,7 @@
 package com.htecgroup.coresample.data.repositories
 
 import com.htecgroup.androidcore.data.CoreRepository
-import com.htecgroup.androidcore.domain.extension.applyIfSome
+import com.htecgroup.androidcore.domain.extension.flatMapIfSome
 import com.htecgroup.androidcore.domain.extension.mapWrapListResult
 import com.htecgroup.androidcore.domain.extension.mapWrapResult
 import com.htecgroup.androidcore.domain.extension.toUnitResult
@@ -49,13 +49,13 @@ class UserRepositoryImpl
     override suspend fun fetchUsers(): Result<Unit> =
         safeApiCall { userApi.getUsers() }
             .map { users -> users.map { it.toUserEntity() } }
-            .applyIfSome { safeDbCall { userDao.updateUsers(it) } }
+            .flatMapIfSome { safeDbCall { userDao.updateUsers(it) } }
             .toUnitResult()
 
     override suspend fun fetchUser(userId: Int): Result<Unit> =
         safeApiCall { userApi.getUser(userId) }
             .map { it.toUserEntity() }
-            .applyIfSome { safeDbCall { userDao.insert(it) } }
+            .flatMapIfSome { safeDbCall { userDao.insert(it) } }
             .toUnitResult()
 
     override suspend fun removeUsers(): Result<Unit> =


### PR DESCRIPTION
# Description

Renamed Result extension `apply` and `applyIfSome` to `flatMap` and `flatMapIfSome` respectively.

Result extension `apply` shares the same name with the Kotlin's scope function `apply` but not the behavior:
- Return value is the lambda return value
- Lambda parameter is an unwrapped `Result` object 

# Checklist:

- [x] My pull request is targeting the main branch.
- [x] I have added a label (feature, bug, dependencies, other).
- [x] I have commented my code, following existing code commenting style.
- [x] I have run and manually tested the Sample app on a real device and/or emulator.
- [x] By submitting the Contribution (as defined in the Apache License available at https://www.apache.org/licenses/LICENSE-2.0.txt, hereinafter referred to as the “Apache License”), you hereby grant and represent that you are legally entitled to grant the License (as defined in the Apache License) to HTEC and recipients of software distributed by HTEC. If your employer(s) has rights to intellectual property that you create that includes your Contributions (as defined in the Apache License), you represent that you have received permission to make Contributions on behalf of that employer, or that your employer has waived such rights for your Contributions to HTEC. If you are submitting the Contribution to HTEC as a legal entity, you hereby represent that you are legally entitled to grant the License. You further represent that each employee designated by you is authorized to submit Contributions on behalf of the legal entity. By submitting the Contribution, you represent that each of your Contributions is your original creation. You further represent that your Contribution submissions include complete details of any third-party license or other restriction (including, but not limited to, related patents and trademarks) of which you are personally aware, and which are associated with any part of your Contributions.